### PR TITLE
BTOB-306 add getLoggableAttributes method to RequestMetaData

### DIFF
--- a/src/RequestMetadata.php
+++ b/src/RequestMetadata.php
@@ -81,7 +81,7 @@ class RequestMetadata
     public function getLoggableAttributes(array $excludeAttributes = []): array
     {
         $attributes = $this->getPlainAttributes();
-        $excludeAttributes = empty($excludeAttributes) ? self::DEFAULT_LOG_EXCLUDED_ATTR : $excludeAttributes;
+        $excludeAttributes = array_merge($excludeAttributes, self::DEFAULT_LOG_EXCLUDED_ATTR);
         foreach ($excludeAttributes as $attribute) {
             if (isset($attributes[$attribute])) {
                 unset($attributes[$attribute]);

--- a/src/RequestMetadata.php
+++ b/src/RequestMetadata.php
@@ -14,6 +14,10 @@ class RequestMetadata
     public const ATTR_CURRENCY = 'currency';
     public const ATTR_JWT = 'jwt';
 
+    private const DEFAULT_LOG_EXCLUDED_ATTR = [
+        self::ATTR_JWT,
+    ];
+    
     /** @var PlainHolder */
     private $plainHolder;
 
@@ -72,6 +76,19 @@ class RequestMetadata
         }
 
         return $result;
+    }
+    
+    public function getLoggableAttributes(array $excludeAttributes = []): array
+    {
+        $attributes = $this->getPlainAttributes();
+        $excludeAttributes = empty($excludeAttributes) ? self::DEFAULT_LOG_EXCLUDED_ATTR : $excludeAttributes;
+        foreach ($excludeAttributes as $attribute) {
+            if (isset($attributes[$attribute])) {
+                unset($attributes[$attribute]);
+            }
+        }
+        
+        return $attributes;
     }
 
 

--- a/tests/RequestMetadataTest.php
+++ b/tests/RequestMetadataTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace TutuRu\Tests\RequestMetadata;
+
+use TutuRu\RequestMetadata\RequestMetadata;
+
+class RequestMetadataTest extends BaseTest
+{
+    public function getLoggableAttributesProvider(): array
+    {
+        return [
+            [[], ['context_test' => 'test', 'uid' => 1], ['uid' => 1]],
+            [['excluded_attr'], ['context_test' => 'test', 'uid' => 1, 'excluded_attr' => 'test'], ['uid' => 1]],
+            [[], ['context_test' => 'test', 'uid' => 1, 'jwt' => 'f23sdf'], ['uid' => 1]],
+        ];
+    }
+    
+    /**
+     * @dataProvider getLoggableAttributesProvider
+     */
+    public function testGetLoggableAttributes(array $excludetAttributes, array $plainAttributes, array $expected): void
+    {
+        $requestMetaData = new RequestMetadata();
+        foreach ($plainAttributes as $key => $value) {
+            $requestMetaData->set($key, $value);
+        }
+        
+        $actual = $requestMetaData->getLoggableAttributes($excludetAttributes);
+        
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
И вот здесь https://github.com/tutu-ru/php-logger-elk/blob/30a2c8cca7a353e36df5e33aefcce9438bb3ff61/src/Redis/RedisMessageProcessor.php#L44 буду этот метод вызывать вместо getPlainAttributes.

Нужно это, чтобы jwt из XRequestId не попадал в логи.